### PR TITLE
Fix some includes for undefined alpha_malloc etc.

### DIFF
--- a/src/core/op_/alphasparse_convert_csr5.c
+++ b/src/core/op_/alphasparse_convert_csr5.c
@@ -1,6 +1,8 @@
+#include "alphasparse.h"
 #include "alphasparse/format.h"
 #include "alphasparse/spmat.h"
 #include "alphasparse/util/check.h"
+#include "alphasparse/util/malloc.h"
 
 #include <stdio.h>
 

--- a/src/core/op_/alphasparse_convert_ell.c
+++ b/src/core/op_/alphasparse_convert_ell.c
@@ -4,6 +4,7 @@
 #include "alphasparse/spmat.h"
 #include "alphasparse/util/check.h"
 #include "alphasparse/util/malloc.h"
+
 alphasparse_status_t convert_ell_datatype_coo(const alpha_internal_spmat *source,
                                              alpha_internal_spmat **dest,
                                              alphasparse_datatype_t datatype) {

--- a/src/core/op_/alphasparse_convert_gebsr.c
+++ b/src/core/op_/alphasparse_convert_gebsr.c
@@ -1,6 +1,8 @@
+#include "alphasparse.h"
 #include "alphasparse/format.h"
 #include "alphasparse/spmat.h"
 #include "alphasparse/util/check.h"
+#include "alphasparse/util/malloc.h"
 
 alphasparse_status_t convert_gebsr_datatype_coo(const alpha_internal_spmat *source,
                                                alpha_internal_spmat **dest,

--- a/src/core/op_/alphasparse_convert_hyb.c
+++ b/src/core/op_/alphasparse_convert_hyb.c
@@ -1,6 +1,8 @@
+#include "alphasparse.h"
 #include "alphasparse/format.h"
 #include "alphasparse/spmat.h"
 #include "alphasparse/util/check.h"
+#include "alphasparse/util/malloc.h"
 
 alphasparse_status_t convert_hyb_datatype_coo(const alpha_internal_spmat *source,
                                              alpha_internal_spmat **dest,

--- a/src/core/op_/alphasparse_convert_sky.c
+++ b/src/core/op_/alphasparse_convert_sky.c
@@ -5,6 +5,7 @@
 #include "alphasparse/spmat.h"
 #include "alphasparse/util/check.h"
 #include "alphasparse/util/malloc.h"
+
 alphasparse_status_t convert_sky_datatype_coo(const alpha_internal_spmat *source,
                                              alpha_internal_spmat **dest,
                                              const alphasparse_fill_mode_t fill,


### PR DESCRIPTION
Was building fine with `gcc`, but `clang` is not happy about missing headers.